### PR TITLE
Add member roles. Fix constraints when deleting members from DB

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -3,3 +3,4 @@
 
 [print_schema]
 file = "src/database/schema.rs"
+patch_file = "src/database/schema.patch"

--- a/migrations/2023-01-17-182938_add_member_role/down.sql
+++ b/migrations/2023-01-17-182938_add_member_role/down.sql
@@ -1,0 +1,14 @@
+ALTER TABLE
+    IF EXISTS public.member
+ADD
+    COLUMN is_apprentice boolean NOT NULL DEFAULT false;
+
+UPDATE
+    public.member
+SET
+    is_apprentice = true
+WHERE
+    role = 1;
+
+ALTER TABLE
+    IF EXISTS public.member DROP COLUMN IF EXISTS role;

--- a/migrations/2023-01-17-182938_add_member_role/up.sql
+++ b/migrations/2023-01-17-182938_add_member_role/up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE
+    IF EXISTS public.member
+ADD
+    COLUMN role integer NOT NULL DEFAULT 0;
+
+UPDATE
+    public.member
+SET
+    role = 1
+WHERE
+    is_apprentice = true;
+
+ALTER TABLE
+    IF EXISTS public.member DROP COLUMN IF EXISTS is_apprentice;

--- a/src/database/models/summary.rs
+++ b/src/database/models/summary.rs
@@ -153,7 +153,7 @@ impl Summary {
         }
         let messages = split_message(summary)?;
 
-        let channel_id = SETTINGS.summary_channel;
+        let channel_id = SETTINGS.discord.summary_channel;
 
         if resend {
             // edit old messages only if there are the same number of messages

--- a/src/database/schema.patch
+++ b/src/database/schema.patch
@@ -1,0 +1,30 @@
+diff --git a/src/database/schema.rs b/src/database/schema.rs
+index 4af3b9f..1a955a4 100644
+--- a/src/database/schema.rs
++++ b/src/database/schema.rs
+@@ -43,23 +43,17 @@ diesel::table! {
+ 
+ diesel::table! {
+     summary (id) {
+         id -> Uuid,
+         note -> Text,
+         create_date -> Date,
+-        messages_id -> Nullable<Array<Nullable<Text>>>,
++        messages_id -> Nullable<Array<Text>>,
+     }
+ }
+ 
+ diesel::joinable!(meeting -> summary (summary_id));
+ diesel::joinable!(meeting_members -> meeting (meeting_id));
+ diesel::joinable!(meeting_members -> member (member_id));
+ diesel::joinable!(report -> member (member_id));
+ diesel::joinable!(report -> summary (summary_id));
+ 
+-diesel::allow_tables_to_appear_in_same_query!(
+-    meeting,
+-    meeting_members,
+-    member,
+-    report,
+-    summary,
+-);
++diesel::allow_tables_to_appear_in_same_query!(meeting, meeting_members, member, report, summary,);

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -1,4 +1,6 @@
-table! {
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
     meeting (id) {
         id -> Uuid,
         start_date -> Timestamp,
@@ -9,7 +11,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     meeting_members (id) {
         id -> Uuid,
         member_id -> Uuid,
@@ -17,18 +19,18 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     member (id) {
         id -> Uuid,
         display_name -> Text,
         discord_id -> Nullable<Text>,
         trello_id -> Nullable<Text>,
         trello_report_card_id -> Nullable<Text>,
-        is_apprentice -> Bool,
+        role -> Int4,
     }
 }
 
-table! {
+diesel::table! {
     report (id) {
         id -> Uuid,
         member_id -> Uuid,
@@ -39,7 +41,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     summary (id) {
         id -> Uuid,
         note -> Text,
@@ -48,10 +50,10 @@ table! {
     }
 }
 
-joinable!(meeting -> summary (summary_id));
-joinable!(meeting_members -> meeting (meeting_id));
-joinable!(meeting_members -> member (member_id));
-joinable!(report -> member (member_id));
-joinable!(report -> summary (summary_id));
+diesel::joinable!(meeting -> summary (summary_id));
+diesel::joinable!(meeting_members -> meeting (meeting_id));
+diesel::joinable!(meeting_members -> member (member_id));
+diesel::joinable!(report -> member (member_id));
+diesel::joinable!(report -> summary (summary_id));
 
-allow_tables_to_appear_in_same_query!(meeting, meeting_members, member, report, summary,);
+diesel::allow_tables_to_appear_in_same_query!(meeting, meeting_members, member, report, summary,);

--- a/src/discord/commands/mod.rs
+++ b/src/discord/commands/mod.rs
@@ -130,12 +130,12 @@ pub fn create_application_commands(
                     })
                     .create_sub_option(|sub_option| {
                         sub_option
-                            .name("is-apprentice")
-                            .description(
-                                "Sets whether member is apprentice or not. Defaults to false",
-                            )
+                            .name("role")
+                            .description("Sets member's role in the team. Defaults to member")
                             .required(false)
-                            .kind(CommandOptionType::Boolean)
+                            .kind(CommandOptionType::String)
+                            .add_string_choice("Member", "member")
+                            .add_string_choice("Apprentice", "apprentice")
                     })
             })
             .create_option(|option| {
@@ -149,6 +149,13 @@ pub fn create_application_commands(
                             .description("Remove member by their ID")
                             .required(true)
                             .kind(CommandOptionType::String)
+                    })
+                    .create_sub_option(|sub_option| {
+                        sub_option
+                            .name("hard-delete")
+                            .description("Hard delete member from the database")
+                            .required(false)
+                            .kind(CommandOptionType::Boolean)
                     })
             })
             .create_option(|option| {
@@ -213,10 +220,12 @@ pub fn create_application_commands(
                     })
                     .create_sub_option(|sub_option| {
                         sub_option
-                            .name("is-apprentice")
-                            .description("Sets whether member is apprentice or not")
+                            .name("role")
+                            .description("Sets member's role in the team. Defaults to member")
                             .required(false)
-                            .kind(CommandOptionType::Boolean)
+                            .kind(CommandOptionType::String)
+                            .add_string_choice("Member", "member")
+                            .add_string_choice("Apprentice", "apprentice")
                     })
             })
     });

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -99,7 +99,7 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("{} is connected!", ready.user.name);
 
-        let guild_id = SETTINGS.server_id;
+        let guild_id = SETTINGS.discord.server_id;
 
         let guild_command = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
             commands::create_application_commands(commands)

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -131,7 +131,7 @@ pub async fn start_bot() {
 
     let framework = StandardFramework::new().configure(|c| c.prefix("~"));
 
-    let mut client = Client::builder(&token, intents)
+    let mut client = Client::builder(token, intents)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,17 +11,22 @@ use tracing::info;
 pub struct Settings {
     pub discord_token: String,
     pub database_url: String,
-    pub member_role_id: RoleId,
-    pub apprentice_role_id: RoleId,
-    pub server_id: GuildId,
     pub meeting: Meeting,
-    pub summary_channel: ChannelId,
+    pub discord: Discord,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Meeting {
     pub channel_id: ChannelId,
     pub cron: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Discord {
+    pub member_role: RoleId,
+    pub apprentice_role: RoleId,
+    pub summary_channel: ChannelId,
+    pub server_id: GuildId,
 }
 
 impl Settings {


### PR DESCRIPTION
Adds member roles. Allows for removal of members without annoying database constraints, by setting user's role as ex-member. Adds support in discord commands. 