### PR TITLE
Ask new members for their discord email to create or connect wiki account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,8 +1285,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 [[package]]
 name = "poise"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d591af1c934c29adda172665f69b837e642d4fee85598baffb95dd98110467d"
+source = "git+https://github.com/serenity-rs/poise.git?rev=5d02b8757d30e4588c193c5ba06e38806bbc1021#5d02b8757d30e4588c193c5ba06e38806bbc1021"
 dependencies = [
  "async-trait",
  "derivative",
@@ -1304,8 +1303,7 @@ dependencies = [
 [[package]]
 name = "poise_macros"
 version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40270099e1527efae99fdc0609d397e76310b529d4980ad38ab14d81803ca0fa"
+source = "git+https://github.com/serenity-rs/poise.git?rev=5d02b8757d30e4588c193c5ba06e38806bbc1021#5d02b8757d30e4588c193c5ba06e38806bbc1021"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ tracing-appender = "0.2.2"
 cron = "0.12.0"
 graphql_client = "0.13.0"
 reqwest = "0.11.19"
-poise = { version = "0.5.5", features = ["cache"] }
+# poise = { version = "0.5.5", features = ["cache"] }
+poise = { git = "https://github.com/serenity-rs/poise.git", rev = "5d02b8757d30e4588c193c5ba06e38806bbc1021", features = ["cache"] }
 anyhow = "1.0.75"
 async-trait = "0.1.73"
 

--- a/src/database/models/member.rs
+++ b/src/database/models/member.rs
@@ -263,11 +263,7 @@ impl Member {
                 return Err(anyhow!(error_msg));
             }
         };
-        let guild_member = match ctx
-            .cache()
-            .unwrap()
-            .member(SETTINGS.discord.server_id, member_id)
-        {
+        let guild_member = match ctx.cache().member(SETTINGS.discord.server_id, member_id) {
             Some(guild_member) => guild_member,
             None => {
                 let error_msg = format!("Member not found in the guild: {}", member_id);

--- a/src/database/models/member.rs
+++ b/src/database/models/member.rs
@@ -187,6 +187,23 @@ impl Member {
         .await
     }
 
+    /// Assigns member appropriate group on wiki. This sould be used when assigning a member role to a user.
+    /// This function will also remove the guest group if the user had one.
+    pub async fn assign_wiki_group_by_role(&self) -> Result<(), Error> {
+        let group_id = match self.role {
+            MemberRole::Member => SETTINGS.wiki.member_group_id,
+            MemberRole::Apprentice => SETTINGS.wiki.member_group_id,
+            MemberRole::ExMember => SETTINGS.wiki.guest_group_id,
+        };
+
+        self.unassign_wiki_group(SETTINGS.wiki.guest_group_id)
+            .await?;
+
+        self.assign_wiki_group(group_id).await?;
+
+        Ok(())
+    }
+
     pub fn hard_delete(&self) -> Result<bool, Error> {
         use crate::database::schema::member::dsl::*;
 

--- a/src/database/models/member.rs
+++ b/src/database/models/member.rs
@@ -190,18 +190,30 @@ impl Member {
     /// Assigns member appropriate group on wiki. This sould be used when assigning a member role to a user.
     /// This function will also remove the guest group if the user had one.
     pub async fn assign_wiki_group_by_role(&self) -> Result<(), Error> {
-        let group_id = match self.role {
-            MemberRole::Member => SETTINGS.wiki.member_group_id,
-            MemberRole::Apprentice => SETTINGS.wiki.member_group_id,
-            MemberRole::ExMember => SETTINGS.wiki.guest_group_id,
-        };
-
-        self.unassign_wiki_group(SETTINGS.wiki.guest_group_id)
-            .await?;
+        let group_id = self.wiki_group();
 
         self.assign_wiki_group(group_id).await?;
 
         Ok(())
+    }
+
+    /// Unassigns member appropriate group on wiki. This sould be used when unassigning a member role to a user.
+    /// This function will also remove the guest group if the user had one.
+    pub async fn unassign_wiki_group_by_role(&self) -> Result<(), Error> {
+        let group_id = self.wiki_group();
+
+        self.unassign_wiki_group(group_id).await?;
+
+        Ok(())
+    }
+
+    /// Returns wiki group id based on member role
+    pub fn wiki_group(&self) -> i64 {
+        match self.role {
+            MemberRole::Member => SETTINGS.wiki.member_group_id,
+            MemberRole::Apprentice => SETTINGS.wiki.member_group_id,
+            MemberRole::ExMember => SETTINGS.wiki.guest_group_id,
+        }
     }
 
     pub fn hard_delete(&self) -> Result<bool, Error> {

--- a/src/discord/commands/member.rs
+++ b/src/discord/commands/member.rs
@@ -61,26 +61,7 @@ pub async fn add_member(
     }
 
     if member.wiki_id().is_some() {
-        if let Err(why) = member
-            .assign_wiki_group(SETTINGS.wiki.member_group_id)
-            .await
-        {
-            let error_msg = format!("Failed to assign wiki group: {}", why);
-            error!("{}", error_msg);
-            output.push_str(&(error_msg + "\n"));
-        }
-
-        match member
-            .unassign_wiki_group(SETTINGS.wiki.guest_group_id)
-            .await
-        {
-            Ok(_) => (),
-            Err(why) => {
-                let error_msg = format!("Failed to unassign wiki group: {}", why);
-                error!("{}", error_msg);
-                output.push_str(&(error_msg + "\n"));
-            }
-        }
+        member.assign_wiki_group_by_role().await?;
     }
 
     let member = match member.insert() {

--- a/src/discord/commands/member.rs
+++ b/src/discord/commands/member.rs
@@ -32,7 +32,7 @@ fn discord_email_button() -> CreateButton {
 }
 
 fn dm_wiki_details<'a, 'b>(c: &'a mut CreateMessage<'b>) -> &'a mut CreateMessage<'b> {
-    c.content("Welcome to Flying Octopus! In order to create your account on our wiki, please provide your Discord email address.")
+    c.content("Welcome to Flying Octopus! In order to create your account on our wiki, please provide your Discord email address (the one you use to log into Discord).")
         .components(|c|
             c.create_action_row(|a|
                 a.add_button(discord_email_button())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,6 +36,7 @@ pub struct Wiki {
     pub url: String,
     pub graphql: String,
     pub token: String,
+    pub provider_key: String,
     pub member_group_id: i64,
     pub guest_group_id: i64,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,6 +34,7 @@ pub struct Discord {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Wiki {
     pub url: String,
+    pub graphql: String,
     pub token: String,
     pub member_group_id: i64,
     pub guest_group_id: i64,

--- a/src/wiki/mod.rs
+++ b/src/wiki/mod.rs
@@ -104,7 +104,7 @@ pub async fn unassign_user_group(variables: unassign_user_group::Variables) -> R
     }
 }
 
-pub async fn create_user(variables: create_user::Variables) -> Result<(), Error> {
+pub async fn create_user(variables: create_user::Variables) -> Result<i64, Error> {
     let client = get_client()?;
 
     let body = CreateUser::build_query(variables);
@@ -117,18 +117,13 @@ pub async fn create_user(variables: create_user::Variables) -> Result<(), Error>
         return Err(anyhow!(response_body.errors.unwrap()[0].message.clone()));
     }
 
-    let response_result = response_body
-        .data
-        .unwrap()
-        .users
-        .unwrap()
-        .create
-        .unwrap()
-        .response_result;
+    let create_user_users_create = response_body.data.unwrap().users.unwrap().create;
+
+    let response_result = &create_user_users_create.as_ref().unwrap().response_result;
 
     if response_result.succeeded {
-        Ok(())
+        Ok(create_user_users_create.unwrap().user.unwrap().id)
     } else {
-        Err(anyhow!(response_result.message.unwrap()))
+        Err(anyhow!(response_result.message.clone().unwrap()))
     }
 }

--- a/src/wiki/mod.rs
+++ b/src/wiki/mod.rs
@@ -20,7 +20,14 @@ pub struct AssignUserGroup;
 )]
 pub struct UnassignUserGroup;
 
-pub async fn assign_user_group(variables: assign_user_group::Variables) -> Result<(), Error> {
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "wiki/schema.graphql",
+    query_path = "wiki/mutations/create_user.graphql"
+)]
+pub struct CreateUser;
+
+fn get_client() -> Result<reqwest::Client, Error> {
     let mut headers = header::HeaderMap::new();
 
     let mut auth_value = header::HeaderValue::from_static(&SETTINGS.wiki.token);
@@ -31,6 +38,12 @@ pub async fn assign_user_group(variables: assign_user_group::Variables) -> Resul
         .user_agent("octobot/".to_owned() + env!("CARGO_PKG_VERSION"))
         .default_headers(headers)
         .build()?;
+
+    Ok(client)
+}
+
+pub async fn assign_user_group(variables: assign_user_group::Variables) -> Result<(), Error> {
+    let client = get_client()?;
 
     let body = AssignUserGroup::build_query(variables);
 
@@ -61,16 +74,7 @@ pub async fn assign_user_group(variables: assign_user_group::Variables) -> Resul
 }
 
 pub async fn unassign_user_group(variables: unassign_user_group::Variables) -> Result<(), Error> {
-    let mut headers = header::HeaderMap::new();
-
-    let mut auth_value = header::HeaderValue::from_static(&SETTINGS.wiki.token);
-    auth_value.set_sensitive(true);
-    headers.insert(header::AUTHORIZATION, auth_value);
-
-    let client = reqwest::Client::builder()
-        .user_agent("octobot/".to_owned() + env!("CARGO_PKG_VERSION"))
-        .default_headers(headers)
-        .build()?;
+    let client = get_client()?;
 
     let body = UnassignUserGroup::build_query(variables);
 
@@ -92,6 +96,35 @@ pub async fn unassign_user_group(variables: unassign_user_group::Variables) -> R
         .unwrap()
         .response_result
         .unwrap();
+
+    if response_result.succeeded {
+        Ok(())
+    } else {
+        Err(anyhow!(response_result.message.unwrap()))
+    }
+}
+
+pub async fn create_user(variables: create_user::Variables) -> Result<(), Error> {
+    let client = get_client()?;
+
+    let body = CreateUser::build_query(variables);
+
+    let res = client.post(&SETTINGS.wiki.url).json(&body).send().await?;
+
+    let response_body: graphql_client::Response<create_user::ResponseData> = res.json().await?;
+
+    if response_body.errors.is_some() {
+        return Err(anyhow!(response_body.errors.unwrap()[0].message.clone()));
+    }
+
+    let response_result = response_body
+        .data
+        .unwrap()
+        .users
+        .unwrap()
+        .create
+        .unwrap()
+        .response_result;
 
     if response_result.succeeded {
         Ok(())

--- a/wiki/mutations/create_user.graphql
+++ b/wiki/mutations/create_user.graphql
@@ -1,0 +1,20 @@
+mutation CreateUser($email: String!, $name: String!, $groups: [Int]!) {
+    users {
+        create(
+            email: $email
+            name: $name
+            providerKey: "Discord"
+            groups: $groups
+        ) {
+            responseResult {
+                succeeded
+                errorCode
+                slug
+                message
+            }
+            user {
+                id
+            }
+        }
+    }
+}

--- a/wiki/mutations/create_user.graphql
+++ b/wiki/mutations/create_user.graphql
@@ -1,9 +1,9 @@
-mutation CreateUser($email: String!, $name: String!, $groups: [Int]!) {
+mutation CreateUser($email: String!, $name: String!, $providerKey: String!, $groups: [Int]!) {
     users {
         create(
             email: $email
             name: $name
-            providerKey: "Discord"
+            providerKey: $providerKey
             groups: $groups
         ) {
             responseResult {

--- a/wiki/queries/search_user.graphql
+++ b/wiki/queries/search_user.graphql
@@ -1,0 +1,9 @@
+query SearchUser($query: String!) {
+    users {
+        search(query: $query) {
+            id
+            name
+            email
+        }
+    }
+}


### PR DESCRIPTION
Bot sends DM to the user asking for the email they use to log in to Discord, to create or connect an account on the wiki. Minor fixes on handling of the wiki groups when updating or deleting user accounts. 